### PR TITLE
Make items unique to collections

### DIFF
--- a/service/api/models.py
+++ b/service/api/models.py
@@ -1,15 +1,25 @@
 from __future__ import unicode_literals
-
 from django.db import models
+from django.contrib.auth.models import User
 
 
 class Collection(models.Model):
-    title = models.CharField(max_length=1000)
-    items = models.ManyToManyField(to='Item')
+    title = models.TextField()
+    description = models.TextField()
+    tags = models.TextField()
+    created_by = models.ForeignKey(User)
+    date_created = models.DateTimeField(auto_now_add=True)
+    date_updated = models.DateTimeField(auto_now=True)
 
 
 class Item(models.Model):
-    _id = models.CharField(max_length=10, default='', primary_key=True)
-    title = models.CharField(max_length=1000)
-    # type = models.CharField(max_length=1000)
+    _id = models.TextField(primary_key=True)
+    title = models.TextField()
+    type = models.TextField()
+    status = models.TextField()
     url = models.URLField()
+    collection = models.ForeignKey(to='Collection')
+    created_by = models.ForeignKey(User)
+    is_displayed = models.BooleanField(default=True)
+    metadata = models.TextField()
+    date_added = models.DateTimeField()

--- a/service/api/models.py
+++ b/service/api/models.py
@@ -13,7 +13,7 @@ class Collection(models.Model):
 
 
 class Item(models.Model):
-    _id = models.TextField(primary_key=True)
+    source_id = models.TextField()
     title = models.TextField()
     type = models.TextField()
     status = models.TextField()

--- a/service/api/serializers.py
+++ b/service/api/serializers.py
@@ -37,12 +37,13 @@ class ItemSerializer(serializers.Serializer):
     def create(self, validated_data):
         user = self.context['request'].user
         collection_id = self.context['request'].parser_context['kwargs'].get('pk', None)
-        collection = None
-        if collection_id:
-            collection = Collection.objects.get(id=collection_id)
+        collection = Collection.objects.get(id=collection_id)
         try:
             item = Item.objects.create(
-              created_by=user, collection=collection, **validated_data)
+                created_by=user,
+                collection=collection,
+                **validated_data
+            )
         except IntegrityError:
             item = Item.objects.get(_id=validated_data['_id'])
         return item

--- a/service/api/serializers.py
+++ b/service/api/serializers.py
@@ -1,25 +1,50 @@
 from django.db import IntegrityError
 from rest_framework import serializers
-from models import Collection, Item
+from models import Collection, Item, User
+
+
+class UserSerializer(serializers.Serializer):
+    id = serializers.CharField(read_only=True)
+    username = serializers.CharField()
+    email = serializers.EmailField()
+
+    def create(self, validated_data):
+        _id = validated_data['id']
+        username = validated_data['username']
+        email = validated_data['email']
+        return User.objects.create_user(
+            id=_id,
+            username=username,
+            email=email,
+            password='password'
+        )
 
 
 class ItemSerializer(serializers.Serializer):
     id = serializers.CharField(source='_id')
     title = serializers.CharField(required=True)
+    type = serializers.CharField()
+    status = serializers.CharField()
     url = serializers.URLField()
+    created_by = UserSerializer(read_only=True)
+    is_displayed = serializers.BooleanField()
+    metadata = serializers.CharField(allow_blank=True)
+    date_added = serializers.DateTimeField()
 
     class Meta:
         model = Item
 
     def create(self, validated_data):
+        user = self.context['request'].user
         collection_id = self.context['request'].parser_context['kwargs'].get('pk', None)
-        try:
-            item = Item.objects.create(**validated_data)
-        except IntegrityError:
-            item = Item.objects.get(_id=validated_data['_id'])
+        collection = None
         if collection_id:
             collection = Collection.objects.get(id=collection_id)
-            collection.items.add(item)
+        try:
+            item = Item.objects.create(
+              created_by=user, collection=collection, **validated_data)
+        except IntegrityError:
+            item = Item.objects.get(_id=validated_data['_id'])
         return item
 
     def update(self, item, validated_data):
@@ -32,18 +57,25 @@ class ItemSerializer(serializers.Serializer):
 class CollectionSerializer(serializers.Serializer):
     id = serializers.CharField(read_only=True)
     title = serializers.CharField(required=True)
-    items = ItemSerializer(
-        many=True,
-        read_only=True
-    )
+    description = serializers.CharField()
+    tags = serializers.CharField()
+    created_by = UserSerializer(read_only=True)
+    date_created = serializers.DateTimeField(read_only=True)
+    date_updated = serializers.DateTimeField(read_only=True)
+    items = serializers.SerializerMethodField()
 
     class Meta:
         model = Collection
 
     def create(self, validated_data):
-        return Collection.objects.create(**validated_data)
+        user = self.context['request'].user
+        return Collection.objects.create(created_by=user, **validated_data)
 
     def update(self, collection, validated_data):
         collection.title = validated_data['title']
         collection.save()
         return collection
+
+    def get_items(self):
+        url = self.context['request'].build_absolute_uri()
+        return url + 'items/'

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -35,7 +35,7 @@ class CollectionItemList(generics.ListCreateAPIView):
         return Item.objects.filter(collection=self.kwargs['pk'])
 
 
-class ItemList(generics.ListCreateAPIView):
+class ItemList(generics.ListAPIView):
     serializer_class = ItemSerializer
 
     def get_queryset(self):

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -50,4 +50,4 @@ class ItemDetail(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = ItemSerializer
 
     def get_object(self):
-        return Item.objects.get(_id=self.kwargs['item_id'])
+        return Item.objects.get(id=self.kwargs['item_id'])

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -32,7 +32,7 @@ class CollectionItemList(generics.ListCreateAPIView):
     serializer_class = ItemSerializer
 
     def get_queryset(self):
-        return [item for item in Collection.objects.filter(id=self.kwargs['pk'])[0].items.all()]
+        return Item.objects.filter(collection=self.kwargs['pk'])
 
 
 class ItemList(generics.ListCreateAPIView):


### PR DESCRIPTION
- Change the many-to-many relationship between collections and items to a "one-to-many" relationship so that collections contain items that are unique to that collection. The item model now has a ForeignKey field to the collection and the item guid is now stored as the `source_id` instead of the `id` which must be unique.
- Make `/items` route view-only since newly created items must belong to a collection
- Add additional fields to Item and Collection models (and to their corresponding DRF serializers)
